### PR TITLE
Added listing users (imported from nugu-api)

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -37,7 +37,7 @@ app.use(writeLog);
 
 app.use('/api', api);
 
-['account', 'forward', 'login', 'logout', 'mailing', 'nugu', 'passwd', 'reset', 'un']
+['account', 'forward', 'login', 'logout', 'mailing', 'nugu', 'passwd', 'reset', 'un', 'users']
   .forEach(r => app.use('/' + r, require('./routers/' + r + '.js')));
 
 app.listen(port, () => {

--- a/server/routers/users.js
+++ b/server/routers/users.js
@@ -5,7 +5,7 @@ const { mysqlQuery } = require('../db.js');
 
 const fields = 'id, name, is_developer, is_designer, is_undergraduate, github_id, linkedin_url, behance_url, website';
 const publicQuery = `SELECT ${fields} FROM user WHERE is_private=0 ORDER BY ent_year DESC`;
-const privateQuery = `SELECT ${fields} FROM user ORDER BY ent_year DESC`;
+const privateQuery = `SELECT ${fields}, is_private FROM user ORDER BY ent_year DESC`;
 
 const router = express.Router();
 /**

--- a/server/routers/users.js
+++ b/server/routers/users.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const auth = require('../auth.js');
+const { success, successWith, failure, errorWith, json } = require('../response.js');
+const { mysqlQuery } = require('../db.js');
+
+const fields = 'id, name, is_developer, is_designer, is_undergraduate, github_id, linkedin_url, behance_url, website';
+const publicQuery = `SELECT ${fields} FROM user WHERE is_private=0 ORDER BY ent_year DESC`;
+const privateQuery = `SELECT ${fields} FROM user ORDER BY ent_year DESC`;
+
+const router = express.Router();
+/**
+ * @api {get} /users/public Get public users
+ * @apiName GetPublicUsers
+ * @apiGroup Users
+ * @apiDescription Get public 'nugu' data of public users
+ *
+ * @apiSuccess {Boolean} success Indicate whether succeeded
+ * @apiSuccess {Object[]} objs List of public 'nugu' data
+ */
+router.get('/public', (req, res) => {
+	mysqlQuery(publicQuery)
+	.then(objs => successWith('objs', objs)())
+	.catch(failure)
+	.then(json(res));
+});
+
+/**
+ * @api {get} /users/all Get all users
+ * @apiName GetAllUsers
+ * @apiGroup Users
+ * @apiDescription Get public 'nugu' data of all users
+ *
+ * @apiSuccess {Boolean} success Indicate whether succeeded
+ * @apiSuccess {Object[]} objs List of public 'nugu' data
+ *
+ * @apiError (Error 401) Unauthorized Not logged in
+ */
+router.get('/all', auth.loginOnly, (req, res) => {
+	mysqlQuery(privateQuery)
+	.then(objs => successWith('objs', objs)())
+	.catch(failure)
+	.then(json(res));
+});
+
+module.exports = router;


### PR DESCRIPTION
Added listing users as it is needed in sparcs.org Home.
Originally, the same feature was in the `nugu-api`.

All of this API Endpoints returns only `id`, `name`, `is_developer`, `is_designer`, `is_undergraduate`, `is_private`, `github_id`, `linkedin_url`, `behance_url`, `website` fields.

* GET /users/all
	* List all users (authorized)

* GET /users/public
	* List all public users