### PR TITLE
[Issue #18] Fixed plain passwords are logged

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -57,7 +57,7 @@ router.post('/login', (req, res) => {
   if (un && pw) {
     exec(`ldapwhoami -H ${ldapHost} -D "uid=${un},ou=People,dc=sparcs,dc=org" -w "${pw}"`,
       { shell: '/bin/sh', uid: nuid }, (err, stdout, stderr) => {
-      logError(req, err);
+      // logError(req, err);
       if (err || stdout.length === 0 || stderr.length !== 0) res.json(fail);
       else {
         req.session.un = _un;


### PR DESCRIPTION
Fixed plain passwords are logged when user is failed to login in memvers.
This pull request fixes #18 